### PR TITLE
CI job deploying the documentation to github pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,27 @@
+name: Build MkDocs and deploy
+
+on: 
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install and Build
+        run: |
+          pip install -r docs/requirements.txt
+          mkdocs build
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: site
+


### PR DESCRIPTION
Hello!

This MR adds a Github Actions CI job which builds the MkDocs documentation from the `main` branch and deploys it to GitHub pages. I've tested it on my account and can confirm that it's working on https://wint3rmute.github.io/mutable-instruments-documentation/

By the way, thanks for documenting the modules! The open-sourced code is already an amazing learning resource for me, now it's getting even better :smile:  